### PR TITLE
Provide ability to include channels by group-title attribute

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -29,6 +29,14 @@
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
+  digest = "1:5f1d44e13c151d777a80b0d8ca850347530773e73ccce5995a520cdc6947c205"
+  name = "github.com/fatih/set"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "2c768e3c5489976167bfc42b5c7c92ca783f4389"
+  version = "v0.2.1"
+
+[[projects]]
   branch = "master"
   digest = "1:36fe9527deed01d2a317617e59304eb2c4ce9f8a24115bcc5c2e37b3aee5bae4"
   name = "github.com/gin-contrib/sse"
@@ -214,6 +222,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/fatih/set",
     "github.com/gin-gonic/gin",
     "github.com/koron/go-ssdp",
     "github.com/mitchellh/mapstructure",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,6 +24,9 @@
 #   go-tests = true
 #   unused-packages = true
 
+[[constraint]]
+  name = "github.com/fatih/set"
+  version = "0.2.1"
 
 [[constraint]]
   name = "github.com/gin-gonic/gin"

--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ IPTV proxy for Plex Live written in Golang
 5) Run `telly` with the `--iptv.playlist` commandline argument pointing to your .m3u file. (This can be a local file or a URL) For example: `./telly --iptv.playlist=/home/github/myiptv.m3u`
 6) If you would like multiple streams/tuners use the `--iptv.streams` commandline option. Default is 1. When setting or changing this option, `plexmediaserver` will need to be completely **restarted**.
 7) If you would like `telly` to attempt to the filter the m3u a bit, add the `--filter.regex` commandline option. If you would like to use your own regex, run `telly` with `--filter.regex="<regex>"`, for example `--filter.regex=".*UK.*"`
-8) If `telly` tells you `[telly] [info] listening on ...` - great! Your .m3u file was successfully parsed and `telly` is running. Check below for how to add it into Plex.
-9) If `telly` fails to run, check the error. If it's self explanatory, great. If you don't understand, feel free to open an issue and we'll help you out. As of telly v0.4 `sed` commands are no longer needed. Woop!
-10) For your IPTV provider m3u, try using option `type=m3u_plus` and `output=ts`.
+8) In addition to regex, the `--filter.groups` parameter allows for a comma-separated list of channel groups to expose. For example; `--filter.groups="Entertainment UK, Documentaries UK"` will expose all channels belonging to the 'Entertainment UK' and 'Documentaries UK' groups as defined by your playlist. Channels must have a valid `group-title` attribute defined within the m3u playlist for this to work.
+9) If `telly` tells you `[telly] [info] listening on ...` - great! Your .m3u file was successfully parsed and `telly` is running. Check below for how to add it into Plex.
+10) If `telly` fails to run, check the error. If it's self explanatory, great. If you don't understand, feel free to open an issue and we'll help you out. As of telly v0.4 `sed` commands are no longer needed. Woop!
+11) For your IPTV provider m3u, try using option `type=m3u_plus` and `output=ts`.
 
-> **Regex handling changed in 1.0.  `filter.regex` has become blacklist which defaults to blocking everything.  If you are not using a regex to filter your M3U file, you will need to add at a minimum `--regex.inclusive=true` to the command line.  If you do not add this, telly will by default EXCLUDE everything in your M3U.  The symptom here is typically telly seeming to start up just fine but reporting 0 channels.**
+> **Regex handling changed in 1.0.  `filter.regex` has become blacklist which defaults to blocking everything.  If you are not using a regex to filter your M3U file, you will need to add at a minimum `--regex.inclusive=true` to the command line.  If you do not add this, telly will by default EXCLUDE everything in your M3U.  The symptom here is typically telly seeming to start up just fine but reporting 0 channels. Note this parameter only affects `filter.regex`, `filter.groups` is always an inclusive list.**
 
 # Adding it into Plex
 

--- a/structs.go
+++ b/structs.go
@@ -13,6 +13,7 @@ import (
 type config struct {
 	RegexInclusive bool
 	Regex          *regexp.Regexp
+	AllowedGroups  string
 
 	DirectMode        bool
 	M3UPath           string


### PR DESCRIPTION
Hi!

Firstly, thanks for working on telly. Its great to have something in place that enables Plex DVR without having to look toward tvheadend or the likes.

One of the features I did like when using tvheadend, was the ability to define a bunch of channel groups a user could access. This effectively acted like a filter, enabling me to pass through a specific set of channels to Plex (much in the vein of how its done via regex in telly).

My provider does not prefix all channels with a country prefix (specifically UK channels), and so I needed a better way to identify these. This PR adds a new config parameter, `--filter.groups` which can be used to specify a comma separated list of channel groups that telly will expose to the client. For example:
```
--filter.groups="Entertainment UK, Documentaries UK, Movies UK, Kids UK"
```
...will bring in all channels that belong to the 4 groups listed. I'm using the `group-title` attribute of the m3u entries to determine these.

There are probably better ways this could be implemented than how I've done this - but I'm a C++ dev (never used Go in my life!) so apologies if this is a little scrappy.

Cheers,
Tom