### PR TITLE
Add CORS headers for Angular

### DIFF
--- a/routes.go
+++ b/routes.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	ssdp "github.com/koron/go-ssdp"
 	"github.com/sirupsen/logrus"
@@ -30,6 +31,7 @@ func serve(lineup *lineup) {
 	}
 
 	router := gin.New()
+	router.Use(cors.Default())
 	router.Use(gin.Recovery())
 
 	if viper.GetBool("log.logrequests") {
@@ -88,9 +90,11 @@ func serve(lineup *lineup) {
 		}
 	}
 
-	log.Infof("telly is live and on the air!")
+	log.Infof("telly is live and on the air! NOW WITH CORS")
 	log.Infof("Broadcasting from http://%s/", viper.GetString("web.listen-address"))
 	log.Infof("EPG URL: http://%s/epg.xml", viper.GetString("web.listen-address"))
+
+
 	if err := router.Run(viper.GetString("web.listen-address")); err != nil {
 		log.WithError(err).Panicln("Error starting up web server")
 	}


### PR DESCRIPTION
Added: https://github.com/gin-contrib/cors

Angular GET requests get blocked by missing CORS headers, adding the header resolves this.